### PR TITLE
Updated README and version while introducing possibility to use wget’…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This is a module that will install Google's Go language for all users.
 
 This module installs GO from OS repo (ie. yum or apt) or staright from Google's repo, making it compatbale with any OS that listed on Google's site https://golang.org/doc/install
 ## Please note !!!!!
-I have depricated installing GO from source as it was making Puppet runs way to long. If you want to keep using this feature please use a version of this module that is 1.* 
-As of 2.* they feature will no long be available.
+I have deprecated installing GO from source as it was making Puppet runs way too long. If you want to keep using this feature please use a version of this module that is 1.*. 
+As of 2.* this feature will no longer be available.
 
 
 ## Usage
@@ -27,7 +27,7 @@ For basic usage:
 ```
 include golang
 ```
-To customise the install please see the below examples. The deafult param is now to install from package !!!! 
+To customize the installation please see the examples below. The deafult param is now to install from package!
 
 To install from golang repo as tar.gz:
 
@@ -35,10 +35,23 @@ To install from golang repo as tar.gz:
 class {'golang':
   base_dir    => '/usr/local/go',
   from_repo   => true,
-  rep_version => 'go1.5.3',
+  rep_version => 'go1.6',
   goroot      => '$GOPATH/bin:/usr/local/go/bin:$PATH',
   workdir     => '/usr/local/',
-  }
+}
+```
+
+If you have issues with older versions of wget and Google's certificate you can disable the certificate check like this:
+
+```puppet
+class {'golang':
+  base_dir               => '/usr/local/go',
+  from_repo              => true,
+  rep_version            => 'go1.6',
+  goroot                 => '$GOPATH/bin:/usr/local/go/bin:$PATH',
+  workdir                => '/usr/local/',
+  wgetnocheckcertificate => true,
+}
 ```
 
 To install from the OS repos (yum or apt)
@@ -57,7 +70,7 @@ Or all data can be set in Hiera ie ```golang::base_dir: /usr/local/go ```
 
 ##Dependencies
 
-This module needs maestrodev/wget
+This module needs [maestrodev/puppet-wget](https://github.com/maestrodev/puppet-wget)
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,12 +2,13 @@
 
 class golang (
 
-  $from_repo           = $golang::params::from_repo,
-  $base_dir            = $golang::params::base_dir,
-  $repo_version        = $golang::params::repo_version,
-  $package_version     = $golang::params::package_version,
-  $goroot              = $golang::params::goroot,
-  $workdir             = $golang::params::workdir,
+  $from_repo           		= $golang::params::from_repo,
+  $base_dir            		= $golang::params::base_dir,
+  $repo_version        		= $golang::params::repo_version,
+  $package_version     		= $golang::params::package_version,
+  $goroot              		= $golang::params::goroot,
+  $workdir             		= $golang::params::workdir,
+  $wgetnocheckcertificate	= $golang::params::wgetnocheckcertificate,
 
 ) inherits golang::params {
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,13 @@
 # This manifest builds Golang
 class golang::install(
   
-  $from_repo       = $golang::from_repo,
-  $repo_version    = $golang::repo_version,
-  $package_version = $golang::package_version,
-  $base_dir        = $golang::base_dir,
-  $workdir         = $golang::workdir,
-  $goroot          = $golang::goroot,
+  $from_repo              = $golang::from_repo,
+  $repo_version           = $golang::repo_version,
+  $package_version        = $golang::package_version,
+  $base_dir               = $golang::base_dir,
+  $workdir                = $golang::workdir,
+  $goroot                 = $golang::goroot,
+  $wgetnocheckcertificate = $golang::wgetnocheckcertificate,
 
   ){
 
@@ -15,10 +16,11 @@ class golang::install(
   if $from_repo {
     
     wget::fetch { 'get golang package':
-    source      => "https://storage.googleapis.com/golang/${repo_version}.linux-amd64.tar.gz",
-    destination => "/tmp/${repo_version}.linux-amd64.tar.gz",
-    timeout     => 0,
-    verbose     => false,
+    source              => "https://storage.googleapis.com/golang/${repo_version}.linux-amd64.tar.gz",
+    destination         => "/tmp/${repo_version}.linux-amd64.tar.gz",
+    timeout             => 0,
+    verbose             => false,
+    nocheckcertificate  => $wgetnocheckcertificate,
     } ->
   
     exec { 'untar go':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class golang::params {
     $repo_version           = 'go1.6'
     $goroot                 = '$GOPATH/bin:/usr/local/go/bin:$PATH'
     $workdir                = '/usr/local/'
-    $wgetnocheckcertificate = false,
+    $wgetnocheckcertificate = false
     }
 
   else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,10 +8,11 @@ class golang::params {
 
 
   if $from_repo {
-    $base_dir        = '/usr/local/go'
-    $repo_version    = 'go1.5.3'
-    $goroot          = '$GOPATH/bin:/usr/local/go/bin:$PATH'
-    $workdir         = '/usr/local/'
+    $base_dir               = '/usr/local/go'
+    $repo_version           = 'go1.6'
+    $goroot                 = '$GOPATH/bin:/usr/local/go/bin:$PATH'
+    $workdir                = '/usr/local/'
+    $wgetnocheckcertificate = false,
     }
 
   else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "scottyc-golang",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "scottyc",
   "summary": "A module for Google's GO language",
   "license": "Apache-2.0",


### PR DESCRIPTION
…s no-check-certificate feature for usage with older wget versions which cannot handle Google’s certificates with SAN names (tested with Debian Squeeze).

Also updated code to use just released Go 1.6
